### PR TITLE
parser: add support for if-else

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2,7 +2,11 @@
 #[derive(Debug, PartialEq, Eq)]
 pub enum Expr<'source, 'arena> {
     Lit(Lit<'source>),
-    Fn,
+    If(
+        &'arena Self,
+        &'arena Block<'source, 'arena>,
+        Option<&'arena Block<'source, 'arena>>,
+    ),
     Block(&'arena Block<'source, 'arena>),
     Ident(Ident<'source>),
     Neg(&'arena Self),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -53,6 +53,10 @@ pub enum Token<'a> {
     Fn,
     #[token("let")]
     Let,
+    #[token("if")]
+    If,
+    #[token("else")]
+    Else,
     #[token("false")]
     False,
     #[token("true")]


### PR DESCRIPTION
Closes https://github.com/lace-language/lace/issues/5

`if` is added at the bottom of the grammar so that this is a valid expression:
```rust
if a { b } else { c } + 5
```

In the block parsing, `if` is treated separately. In that case:
1. It cannot be followed by anything.
2. The semicolon is optional.

Questions:
- Should `If` be separate in the AST from `IfElse`?
- Does this really work? I'm kind of surprised how simple the solution is in the end. I bet there's some way it breaks.