### PR TITLE
AST/parser: spans are stored in a `Vec`

### DIFF
--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,4 +1,4 @@
-use crate::parser::span::{Span, Spanned};
+use crate::parser::span::Spanned;
 
 pub type Expr<'s, 'a> = Spanned<ExprKind<'s, 'a>>;
 
@@ -8,10 +8,10 @@ pub enum ExprKind<'s, 'a> {
     Lit(Lit<'s>),
     If(
         &'a Spanned<Self>,
-        &'a Block<'s, 'a>,
-        Option<&'a Block<'s, 'a>>,
+        &'a Spanned<Block<'s, 'a>>,
+        Option<&'a Spanned<Block<'s, 'a>>>,
     ),
-    Block(&'a Block<'s, 'a>),
+    Block(&'a Spanned<Block<'s, 'a>>),
     Ident(Ident<'s>),
     Neg(&'a Spanned<Self>),
     Paren(&'a Spanned<Self>),
@@ -55,14 +55,13 @@ pub struct Function<'s, 'a> {
     pub parameters: &'a [Parameter<'s>],
     pub ret: Option<Spanned<TypeSpec<'s>>>,
 
-    pub block: &'a Block<'s, 'a>,
+    pub block: &'a Spanned<Block<'s, 'a>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Block<'s, 'a> {
     pub stmts: &'a [Statement<'s, 'a>],
     pub last: Option<Expr<'s, 'a>>,
-    pub span: Span,
 }
 
 /// Literal values

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -60,7 +60,7 @@ impl<'s, 'a> Parser<'s, 'a> {
     fn inversion(&mut self) -> ParseResult<Expr<'s, 'a>> {
         if let Some(span) = self.accept_optional(tok![!])? {
             let arg = self.inversion()?;
-            let span = self.spans.store_merged(span, arg.span());
+            let span = self.spans.store_merged(span, &arg);
             Ok(ExprKind::Not(self.alloc(arg)).with_span(span))
         } else {
             self.sum()
@@ -112,7 +112,7 @@ impl<'s, 'a> Parser<'s, 'a> {
     fn factor(&mut self) -> ParseResult<Expr<'s, 'a>> {
         if let Some(span) = self.accept_optional(tok![-])? {
             let arg = self.call_expr()?;
-            let span = self.spans.store_merged(span, arg.span());
+            let span = self.spans.store_merged(span, &arg);
             Ok(ExprKind::Neg(self.alloc(arg)).with_span(span))
         } else {
             self.call_expr()

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -16,7 +16,7 @@ impl<'s, 'a> Parser<'s, 'a> {
         let mut left = self.conjunction()?;
         while self.accept_optional(tok![||])?.is_some() {
             let right = self.conjunction()?;
-            let span = left.span().merge(right.span());
+            let span = self.spans.merge(&left, &right);
             left = ExprKind::LogicalOr(self.alloc(left), self.alloc(right)).with_span(span)
         }
         Ok(left)
@@ -28,7 +28,7 @@ impl<'s, 'a> Parser<'s, 'a> {
         let mut left = self.comparison()?;
         while self.accept_optional(tok![&&])?.is_some() {
             let right = self.comparison()?;
-            let span = left.span().merge(right.span());
+            let span = self.spans.merge(&left, &right);
             left = ExprKind::LogicalAnd(self.alloc(left), self.alloc(right)).with_span(span);
         }
         Ok(left)
@@ -47,7 +47,7 @@ impl<'s, 'a> Parser<'s, 'a> {
         for (t, f) in tokens {
             if self.accept_optional(*t)?.is_some() {
                 let right = self.inversion()?;
-                let span = left.span().merge(right.span());
+                let span = self.spans.merge(&left, &right);
                 return Ok(f(self.alloc(left), self.alloc(right)).with_span(span));
             }
         }
@@ -60,7 +60,7 @@ impl<'s, 'a> Parser<'s, 'a> {
     fn inversion(&mut self) -> ParseResult<Expr<'s, 'a>> {
         if let Some(span) = self.accept_optional(tok![!])? {
             let arg = self.inversion()?;
-            let span = span.merge(arg.span());
+            let span = self.spans.store_merged(span, arg.span());
             Ok(ExprKind::Not(self.alloc(arg)).with_span(span))
         } else {
             self.sum()
@@ -75,11 +75,11 @@ impl<'s, 'a> Parser<'s, 'a> {
         loop {
             if self.accept_optional(tok![+])?.is_some() {
                 let right = self.term()?;
-                let span = left.span().merge(right.span());
+                let span = self.spans.merge(&left, &right);
                 left = ExprKind::Add(self.alloc(left), self.alloc(right)).with_span(span);
             } else if self.accept_optional(tok![-])?.is_some() {
                 let right = self.term()?;
-                let span = left.span().merge(right.span());
+                let span = self.spans.merge(&left, &right);
                 left = ExprKind::Sub(self.alloc(left), self.alloc(right)).with_span(span);
             } else {
                 return Ok(left);
@@ -95,11 +95,11 @@ impl<'s, 'a> Parser<'s, 'a> {
         loop {
             if self.accept_optional(tok![*])?.is_some() {
                 let right = self.factor()?;
-                let span = left.span().merge(right.span());
+                let span = self.spans.merge(&left, &right);
                 left = ExprKind::Mul(self.alloc(left), self.alloc(right)).with_span(span);
             } else if self.accept_optional(tok![/])?.is_some() {
                 let right = self.factor()?;
-                let span = left.span().merge(right.span());
+                let span = self.spans.merge(&left, &right);
                 left = ExprKind::Div(self.alloc(left), self.alloc(right)).with_span(span);
             } else {
                 return Ok(left);
@@ -112,7 +112,7 @@ impl<'s, 'a> Parser<'s, 'a> {
     fn factor(&mut self) -> ParseResult<Expr<'s, 'a>> {
         if let Some(span) = self.accept_optional(tok![-])? {
             let arg = self.call_expr()?;
-            let span = span.merge(arg.span());
+            let span = self.spans.store_merged(span, arg.span());
             Ok(ExprKind::Neg(self.alloc(arg)).with_span(span))
         } else {
             self.call_expr()
@@ -126,7 +126,7 @@ impl<'s, 'a> Parser<'s, 'a> {
         if let Some(end_span) = self.accept_optional(Token::RoundRight)? {
             // yes, this is really necessary.
             let a: &[_] = &[];
-            return Ok(a.with_span(start_span.merge(&end_span)));
+            return Ok(a.with_span(self.spans.store(start_span.merge(&end_span))));
         }
 
         let mut parameters = Vec::new_in(self.arena);
@@ -137,7 +137,7 @@ impl<'s, 'a> Parser<'s, 'a> {
             if let Some(end_span) = self.accept_optional(Token::RoundRight)? {
                 return Ok(parameters
                     .into_bump_slice()
-                    .with_span(start_span.merge(&end_span)));
+                    .with_span(self.spans.store(start_span.merge(&end_span))));
             }
 
             parameters.push(self.expr()?);
@@ -147,7 +147,7 @@ impl<'s, 'a> Parser<'s, 'a> {
 
         Ok(parameters
             .into_bump_slice()
-            .with_span(start_span.merge(&end_span)))
+            .with_span(self.spans.store(start_span.merge(&end_span))))
     }
 
     fn call_expr(&mut self) -> ParseResult<Expr<'s, 'a>> {
@@ -156,7 +156,7 @@ impl<'s, 'a> Parser<'s, 'a> {
         if self.peek_is(Token::RoundLeft)? {
             let args = self.call_args()?;
 
-            let span = atom.span().merge(args.span());
+            let span = self.spans.merge(&atom, &args);
             Ok(ExprKind::Call(self.alloc(atom), args).with_span(span))
         } else {
             Ok(atom)
@@ -177,6 +177,7 @@ impl<'s, 'a> Parser<'s, 'a> {
         }
 
         let (token, span) = self.next()?;
+        let span = self.spans.store(span);
         let expr = match token {
             Token::Ident(s) => ExprKind::Ident(Ident { string: s }).with_span(span),
             Token::False => ExprKind::Lit(Lit::Bool(false)).with_span(span),
@@ -194,21 +195,25 @@ impl<'s, 'a> Parser<'s, 'a> {
             return Err(ParseError::Expected);
         };
 
-        Ok(Ident { string: name }.with_span(name_span))
+        Ok(Ident { string: name }.with_span(self.spans.store(name_span)))
     }
 
     fn paren(&mut self) -> ParseResult<Expr<'s, 'a>> {
         let start_span = self.accept_required(Token::RoundLeft)?;
 
         if let Some(end_span) = self.accept_optional(Token::RoundRight)? {
-            return Ok(ExprKind::Tuple(&[]).with_span(start_span.merge(&end_span)));
+            return Ok(
+                ExprKind::Tuple(&[]).with_span(self.spans.store(start_span.merge(&end_span)))
+            );
         }
 
         let expr = self.expr()?;
 
         if let Some(end_span) = self.accept_optional(Token::RoundRight)? {
             let expr = self.alloc(expr);
-            return Ok(ExprKind::Paren(expr).with_span(start_span.merge(&end_span)));
+            return Ok(
+                ExprKind::Paren(expr).with_span(self.spans.store(start_span.merge(&end_span)))
+            );
         }
 
         let mut vec = Vec::new_in(self.arena);
@@ -217,7 +222,9 @@ impl<'s, 'a> Parser<'s, 'a> {
         while self.accept_optional(tok![,])?.is_some() {
             if let Some(end_span) = self.accept_optional(Token::RoundRight)? {
                 let slice = vec.into_bump_slice();
-                return Ok(ExprKind::Tuple(slice).with_span(start_span.merge(&end_span)));
+                return Ok(
+                    ExprKind::Tuple(slice).with_span(self.spans.store(start_span.merge(&end_span)))
+                );
             }
             vec.push(self.expr()?);
         }
@@ -225,6 +232,6 @@ impl<'s, 'a> Parser<'s, 'a> {
         let end_span = self.accept_required(Token::RoundRight)?;
         let slice = vec.into_bump_slice();
 
-        Ok(ExprKind::Tuple(slice).with_span(start_span.merge(&end_span)))
+        Ok(ExprKind::Tuple(slice).with_span(self.spans.store(start_span.merge(&end_span))))
     }
 }

--- a/src/parser/function.rs
+++ b/src/parser/function.rs
@@ -51,7 +51,7 @@ impl<'s, 'a> Parser<'s, 'a> {
         };
 
         let block = self.block()?;
-        let fn_span = start_span.merge(&block.span);
+        let fn_span = self.spans.store_merged(start_span, block.span());
 
         Ok(Function {
             name,

--- a/src/parser/function.rs
+++ b/src/parser/function.rs
@@ -51,7 +51,7 @@ impl<'s, 'a> Parser<'s, 'a> {
         };
 
         let block = self.block()?;
-        let fn_span = self.spans.store_merged(start_span, block.span());
+        let fn_span = self.spans.store_merged(start_span, &block);
 
         Ok(Function {
             name,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,6 @@
 use crate::lexer::{Lexer, Token};
 use crate::parser::ast::File;
-use crate::parser::span::Span;
+use crate::parser::span::{Span, Spans};
 use bumpalo::Bump;
 use error::{ParseError, ParseResult};
 use std::iter::Peekable;
@@ -22,6 +22,7 @@ pub mod test;
 pub struct Parser<'s, 'a> {
     _source: &'s str,
     lexer: Peekable<Lexer<'s>>,
+    spans: Spans,
     arena: &'a Bump,
 }
 
@@ -30,6 +31,7 @@ impl<'s, 'a> Parser<'s, 'a> {
         Self {
             _source: source,
             lexer: logos::Lexer::new(source).spanned().peekable(),
+            spans: Spans::new(),
             arena,
         }
     }

--- a/src/parser/span.rs
+++ b/src/parser/span.rs
@@ -29,7 +29,13 @@ impl Spans {
         self.store(a.merge(&b))
     }
 
-    pub fn store_merged(&mut self, span: Span, NodeId(a): NodeId) -> NodeId {
+    pub fn store_merged<T>(
+        &mut self,
+        span: Span,
+        &Spanned {
+            span: NodeId(a), ..
+        }: &Spanned<T>,
+    ) -> NodeId {
         let a = self.0[a];
         self.store(span.merge(&a))
     }

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -90,7 +90,7 @@ impl<'s, 'a> Parser<'s, 'a> {
                 self.block()?
             };
 
-            let span = self.spans.store_merged(start_span, else_block.span());
+            let span = self.spans.store_merged(start_span, &else_block);
             Ok(ExprKind::If(
                 self.alloc(expr),
                 self.alloc(then_block),
@@ -98,7 +98,7 @@ impl<'s, 'a> Parser<'s, 'a> {
             )
             .with_span(span))
         } else {
-            let span = self.spans.store_merged(start_span, then_block.span());
+            let span = self.spans.store_merged(start_span, &then_block);
             Ok(ExprKind::If(self.alloc(expr), self.alloc(then_block), None).with_span(span))
         }
     }

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -200,10 +200,10 @@ macro_rules! call {
 
 macro_rules! block {
     ($($stmts:pat),*) => {
-        Block { stmts: &[$($stmts),*], last: None, .. }
+        spanned!(Block { stmts: &[$($stmts),*], last: None, .. })
     };
     ($($stmts:pat),* => $exp:pat) => {
-        Block { stmts: &[$($stmts),*], last: Some($exp), .. }
+        spanned!(Block { stmts: &[$($stmts),*], last: Some($exp), .. })
     };
 }
 

--- a/src/parser/type_spec.rs
+++ b/src/parser/type_spec.rs
@@ -6,7 +6,7 @@ use crate::parser::Parser;
 impl<'s, 'a> Parser<'s, 'a> {
     pub(super) fn type_spec(&mut self) -> ParseResult<Spanned<TypeSpec<'s>>> {
         let name = self.ident()?;
-        let span = *name.span();
+        let span = name.span();
 
         Ok(TypeSpec::Name(name).with_span(span))
     }


### PR DESCRIPTION
This is kind of a rough sketch. I think the API can be improved, so suggestions are welcome.