### PR TITLE
Re-implement expression parsing

### DIFF
--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -17,6 +17,15 @@ pub enum ParseError {
         #[label("expected {expected}")]
         span: Span,
     },
+    #[error("The chained binary operators `{lhs}` and `{rhs}` are incompatible")]
+    IncompatBinOp {
+        lhs: String,
+        rhs: String,
+        #[label("the first operator")]
+        lhs_span: Span,
+        #[label("the second operator")]
+        rhs_span: Span,
+    },
     // TODO: Figure out how to get the error from logos
     #[error("Unrecognized token")]
     UnrecognizedToken {

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1,122 +1,260 @@
+use std::cmp::Ordering;
 use crate::lexer::Token;
 use crate::parser::ast::{Expr, ExprKind, Ident, Lit};
 use crate::parser::error::{ParseError, ParseResult};
-use crate::parser::span::{Spanned, WithSpan};
+use crate::parser::span::{Spanned, WithSpan, Span};
 use crate::parser::Parser;
 use bumpalo::collections::Vec;
 
+/// A binary operator.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum BinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+
+    IsEQ,
+    IsNE,
+    IsLT,
+    IsLE,
+    IsGT,
+    IsGE,
+
+    Con,
+    Dis,
+}
+
+impl BinOp {
+    /// The precedence of this operator.
+    pub fn prec(&self) -> Prec {
+        match self {
+            Self::Add | Self::Sub => Prec::AddSub,
+            Self::Mul | Self::Div => Prec::MulDiv,
+            Self::IsEQ | Self::IsNE
+                | Self::IsLT | Self::IsLE
+                | Self::IsGT | Self::IsGE
+                => Prec::Compare,
+            Self::Con => Prec::Con,
+            Self::Dis => Prec::Dis,
+        }
+    }
+
+    /// The token for this operator.
+    pub fn token(&self) -> Token<'static> {
+        match self {
+            Self::Add => tok![+],
+            Self::Sub => tok![-],
+            Self::Mul => tok![*],
+            Self::Div => tok![/],
+            Self::IsEQ => tok![==],
+            Self::IsNE => tok![!=],
+            Self::IsLT => tok![<],
+            Self::IsLE => tok![<=],
+            Self::IsGT => tok![>],
+            Self::IsGE => tok![>=],
+            Self::Con => tok![&&],
+            Self::Dis => tok![||],
+        }
+    }
+
+    /// Construct a new [`ExprKind`] of this operator.
+    pub fn into_expr<'s, 'a>(
+        self,
+        lhs: &'a Expr<'s, 'a>,
+        rhs: &'a Expr<'s, 'a>,
+    ) -> ExprKind<'s, 'a> {
+        (match self {
+            Self::Add => ExprKind::Add,
+            Self::Sub => ExprKind::Sub,
+            Self::Mul => ExprKind::Mul,
+            Self::Div => ExprKind::Div,
+            Self::IsEQ => ExprKind::Eq,
+            Self::IsNE => ExprKind::Neq,
+            Self::IsLT => ExprKind::Lt,
+            Self::IsLE => ExprKind::Lte,
+            Self::IsGT => ExprKind::Gt,
+            Self::IsGE => ExprKind::Gte,
+            Self::Con => ExprKind::LogicalAnd,
+            Self::Dis => ExprKind::LogicalOr,
+        })(lhs, rhs)
+    }
+}
+
+/// Operator precedence.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Prec {
+    /// The precedence of logical disjunction.
+    Dis,
+
+    /// The precedence of logical conjunction.
+    Con,
+
+    /// The precedence of comparison operators.
+    Compare,
+
+    /// The precedence of addition and subtraction.
+    AddSub,
+
+    /// The precedence of multiplication and division.
+    MulDiv,
+}
+
+impl Prec {
+    /// The associativity for operators at this precedence.
+    ///
+    /// If [`None`] is returned, then operators at this precedence cannot be chained to each other.
+    pub fn assoc(&self) -> Option<Assoc> {
+        match self {
+            Self::Dis => Some(Assoc::Left),
+            Self::Con => Some(Assoc::Left),
+            Self::Compare => None,
+            Self::AddSub => Some(Assoc::Left),
+            Self::MulDiv => Some(Assoc::Left),
+        }
+    }
+
+    /// Determine the associativity between two operators.
+    ///
+    /// Given two operators `a` and `b` in the expression `x <a> y <b> z`, this function returns
+    /// [`Assoc::Left`] if `y` binds to `a` or [`Assoc::Right`] if `y` binds to `b`.  If `a` and
+    /// `b` cannot be chained, [`None`] will be returned instead.
+    pub fn cmp(lhs: Self, rhs: Self) -> Option<Assoc> {
+        match PartialOrd::partial_cmp(&lhs, &rhs)? {
+            Ordering::Less => Some(Assoc::Right),
+            Ordering::Equal => lhs.assoc(),
+            Ordering::Greater => Some(Assoc::Left),
+        }
+    }
+}
+
+impl PartialOrd for Prec {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let (lhs, rhs) = (*self, *other);
+        Some(Ord::cmp(&(lhs as usize), &(rhs as usize)))
+    }
+}
+
+/// The associativity of an operator.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Assoc {
+    /// Left associativity.
+    ///
+    /// `<x> o <y> o <z>` is parsed as `(<x> o <y>) o <z>`.
+    Left,
+
+    /// Right associativity.
+    ///
+    /// `<x> o <y> o <z>` is parsed as `<x> o (<y> o <z>)`.
+    Right,
+}
+
 impl<'s, 'a> Parser<'s, 'a> {
     // TODO: Proper error handling
-    // TODO: Function calls
     pub fn expr(&mut self) -> ParseResult<Expr<'s, 'a>> {
-        self.disjunction()
+        self.prec_expr(None)
     }
 
-    fn disjunction(&mut self) -> ParseResult<Expr<'s, 'a>> {
-        let mut left = self.conjunction()?;
-        while self.accept_optional(tok![||])?.is_some() {
-            let right = self.conjunction()?;
-            let span = self.spans.merge(&left, &right);
-            left = ExprKind::LogicalOr(self.alloc(left), self.alloc(right)).with_span(span)
+    fn prec_expr(
+        &mut self,
+        prev: Option<(BinOp, Span)>,
+    ) -> ParseResult<Expr<'s, 'a>> {
+        // The expression parsed thus far.
+        let mut expr = self.unary_expr()?;
+
+        // Try extending into a larger binary operation.
+        while let Some(next) = self.binop(prev)? {
+            // Get the right-hand side of this operation.
+            let rhs = self.prec_expr(Some(next))?;
+
+            // Construct the new binary operation.
+            let span = self.spans.merge(&expr, &rhs);
+            let [lhs, rhs] = [expr, rhs].map(|x| self.alloc(x));
+            expr = next.0.into_expr(lhs, rhs).with_span(span);
         }
-        Ok(left)
+
+        Ok(expr)
     }
 
-    // conjunction = conjunction 'and' inversion
-    //             | inversion
-    fn conjunction(&mut self) -> ParseResult<Expr<'s, 'a>> {
-        let mut left = self.comparison()?;
-        while self.accept_optional(tok![&&])?.is_some() {
-            let right = self.comparison()?;
-            let span = self.spans.merge(&left, &right);
-            left = ExprKind::LogicalAnd(self.alloc(left), self.alloc(right)).with_span(span);
+    /// Determine the associativity between two binary operators.
+    fn binop(&mut self, lhs: Option<(BinOp, Span)>) -> ParseResult<Option<(BinOp, Span)>> {
+        let Some(rhs) = self.peek_binop()? else { return Ok(None) };
+        let Some(lhs) = lhs else {
+            let (_, rhs_span) = self.next()?;
+            return Ok(Some((rhs, rhs_span)));
+        };
+
+        if let Some(assoc) = Prec::cmp(lhs.0.prec(), rhs.prec()) {
+            // The operators are compatible, succeed.
+            if assoc == Assoc::Right {
+                let (_, rhs_span) = self.next()?;
+                return Ok(Some((rhs, rhs_span)));
+            } else {
+                return Ok(None);
+            }
         }
-        Ok(left)
+
+        let (_, rhs_span) = self.next()?;
+        Err(ParseError::IncompatBinOp {
+            lhs: lhs.0.token().to_string(),
+            rhs: rhs.token().to_string(),
+            lhs_span: lhs.1,
+            rhs_span,
+        })
     }
 
-    fn comparison(&mut self) -> ParseResult<Expr<'s, 'a>> {
-        let left = self.inversion()?;
-        let tokens: &[(_, fn(_, _) -> _)] = &[
-            (tok![==], ExprKind::Eq),
-            (tok![!=], ExprKind::Neq),
-            (tok![>=], ExprKind::Gte),
-            (tok![<=], ExprKind::Lte),
-            (tok![>], ExprKind::Gt),
-            (tok![<], ExprKind::Lt),
+    /// Peek to find a binary operator.
+    fn peek_binop(&mut self) -> ParseResult<Option<BinOp>> {
+        let operators = [
+            BinOp::Add,
+            BinOp::Sub,
+            BinOp::Mul,
+            BinOp::Div,
+            BinOp::IsEQ,
+            BinOp::IsNE,
+            BinOp::IsLT,
+            BinOp::IsLE,
+            BinOp::IsGT,
+            BinOp::IsGE,
+            BinOp::Con,
+            BinOp::Dis,
         ];
-        for (t, f) in tokens {
-            if self.accept_optional(*t)?.is_some() {
-                let right = self.inversion()?;
-                let span = self.spans.merge(&left, &right);
-                return Ok(f(self.alloc(left), self.alloc(right)).with_span(span));
+
+        let Some(token) = self.peek()? else { return Ok(None) };
+        Ok(operators.into_iter().find(|o| o.token() == token))
+    }
+
+    /// Parse a unary expression.
+    fn unary_expr(&mut self) -> ParseResult<Expr<'s, 'a>> {
+        // Try parsing a prefix operation.
+        let prefix_ops: [(_, fn(_) -> _); 2] = [
+            (tok![-], ExprKind::Neg),
+            (tok![!], ExprKind::Not),
+        ];
+        for (token, constructor) in prefix_ops {
+            if let Some(span) = self.accept_optional(token)? {
+                let inner = self.unary_expr()?;
+                let span = self.spans.store_merged(span, &inner);
+                let inner = self.alloc(inner);
+                return Ok((constructor)(inner).with_span(span));
             }
         }
-        Ok(left)
-    }
 
-    // inversion = '!' inversion
-    //           | sum
-    // TODO: this should go to comparison
-    fn inversion(&mut self) -> ParseResult<Expr<'s, 'a>> {
-        if let Some(span) = self.accept_optional(tok![!])? {
-            let arg = self.inversion()?;
-            let span = self.spans.store_merged(span, &arg);
-            Ok(ExprKind::Not(self.alloc(arg)).with_span(span))
-        } else {
-            self.sum()
-        }
-    }
+        // Parse the basic atom within the expression.
+        let mut expr = self.atom()?;
 
-    // sum = sum '+' term
-    //     | sum '-' term
-    //     | term
-    fn sum(&mut self) -> ParseResult<Expr<'s, 'a>> {
-        let mut left = self.term()?;
+        // Try parsing suffix operations.
         loop {
-            if self.accept_optional(tok![+])?.is_some() {
-                let right = self.term()?;
-                let span = self.spans.merge(&left, &right);
-                left = ExprKind::Add(self.alloc(left), self.alloc(right)).with_span(span);
-            } else if self.accept_optional(tok![-])?.is_some() {
-                let right = self.term()?;
-                let span = self.spans.merge(&left, &right);
-                left = ExprKind::Sub(self.alloc(left), self.alloc(right)).with_span(span);
+            if self.peek_is(Token::RoundLeft)? {
+                let args = self.call_args()?;
+                let span = self.spans.merge(&expr, &args);
+                expr = ExprKind::Call(self.alloc(expr), args).with_span(span);
             } else {
-                return Ok(left);
+                break;
             }
         }
-    }
 
-    // term = term '*' factor
-    //      | term '/' factor
-    //      | factor
-    fn term(&mut self) -> ParseResult<Expr<'s, 'a>> {
-        let mut left = self.factor()?;
-        loop {
-            if self.accept_optional(tok![*])?.is_some() {
-                let right = self.factor()?;
-                let span = self.spans.merge(&left, &right);
-                left = ExprKind::Mul(self.alloc(left), self.alloc(right)).with_span(span);
-            } else if self.accept_optional(tok![/])?.is_some() {
-                let right = self.factor()?;
-                let span = self.spans.merge(&left, &right);
-                left = ExprKind::Div(self.alloc(left), self.alloc(right)).with_span(span);
-            } else {
-                return Ok(left);
-            }
-        }
-    }
-
-    // factor = '-' atom
-    //        | atom
-    fn factor(&mut self) -> ParseResult<Expr<'s, 'a>> {
-        if let Some(span) = self.accept_optional(tok![-])? {
-            let arg = self.call_expr()?;
-            let span = self.spans.store_merged(span, &arg);
-            Ok(ExprKind::Neg(self.alloc(arg)).with_span(span))
-        } else {
-            self.call_expr()
-        }
+        Ok(expr)
     }
 
     fn call_args(&mut self) -> ParseResult<Spanned<&'a [Expr<'s, 'a>]>> {
@@ -148,19 +286,6 @@ impl<'s, 'a> Parser<'s, 'a> {
         Ok(parameters
             .into_bump_slice()
             .with_span(self.spans.store(start_span.merge(&end_span))))
-    }
-
-    fn call_expr(&mut self) -> ParseResult<Expr<'s, 'a>> {
-        let atom = self.atom()?;
-
-        if self.peek_is(Token::RoundLeft)? {
-            let args = self.call_args()?;
-
-            let span = self.spans.merge(&atom, &args);
-            Ok(ExprKind::Call(self.alloc(atom), args).with_span(span))
-        } else {
-            Ok(atom)
-        }
     }
 
     fn atom(&mut self) -> ParseResult<Expr<'s, 'a>> {

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -285,6 +285,7 @@ fn integers() {
 #[test]
 fn unary() {
     assert_expr_matches!("- 2", neg!(int!(2)));
+    assert_expr_matches!("- 2 + 3", add!(neg!(int!(2)), int!(3)));
 }
 
 #[test]
@@ -437,6 +438,8 @@ fn strings() {
 #[test]
 fn call() {
     assert_expr_matches!("a()", call!(ident_expr!(a) => []));
+    assert_expr_matches!("a(1)(2)", call!(call!(ident_expr!(a) => [int!(1)]) => [int!(2)]));
+    assert_expr_matches!("-a(1)", neg!(call!(ident_expr!(a) => [int!(1)])));
     assert_expr_matches!(
         "a(1, 2, 3)",
         call!(

--- a/src/parser/test.rs
+++ b/src/parser/test.rs
@@ -438,7 +438,10 @@ fn strings() {
 #[test]
 fn call() {
     assert_expr_matches!("a()", call!(ident_expr!(a) => []));
-    assert_expr_matches!("a(1)(2)", call!(call!(ident_expr!(a) => [int!(1)]) => [int!(2)]));
+    assert_expr_matches!(
+        "a(1)(2)",
+        call!(call!(ident_expr!(a) => [int!(1)]) => [int!(2)])
+    );
     assert_expr_matches!("-a(1)", neg!(call!(ident_expr!(a) => [int!(1)])));
     assert_expr_matches!(
         "a(1, 2, 3)",


### PR DESCRIPTION
Rather than relying on a separate function for each set of binary operators, I've introduced a single set of functions for parsing arbitrary binary operators, using precedence and associativity computations to decide the how to structure the operators.  I've also rewritten how unary expressions are parsed; they're now entirely handled by a single `unary_expr()` function, which checks for all prefix and postfix operators.  I believe that this makes the structure of parsing for expressions much, much clearer.